### PR TITLE
Add fluxctl package via Brew

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -66,7 +66,7 @@ echo "Installing SRE packages..."
 sudo -u $mostCommonUser $brew_path install terraform terragrunt
 
 echo "Installing Kubernetes packages..."
-sudo -u $mostCommonUser $brew_path install kubectl kubectx helm stern
+sudo -u $mostCommonUser $brew_path install kubectl kubectx helm stern fluxctl
 
 if [[ -f "/Users/${mostCommonUser}/.zshrc" ]]; then
   cat /Users/${mostCommonUser}/.zshrc | uniq > /Users/${mostCommonUser}/.zshrc.clean && mv /Users/${mostCommonUser}/.zshrc.clean /Users/${mostCommonUser}/.zshrc


### PR DESCRIPTION
- Add `fluxctl` as a Brew package, as we are using it to manage Helm rollouts and adding it to runbooks + documentation.