### PR TITLE
Add mkcert & nss to engineer packages

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -59,7 +59,7 @@ sudo -u $mostCommonUser $brew_path tap homebrew/core
 sudo -u $mostCommonUser $brew_path install --cask google-cloud-sdk
 
 echo "Installing engineering packages..."
-sudo -u $mostCommonUser $brew_path install cloudflared coreutils gawk httpie jq pgcli postgresql pre-commit teleport watch yamllint yq 
+sudo -u $mostCommonUser $brew_path install cloudflared coreutils gawk httpie jq mkcert nss pgcli postgresql pre-commit teleport watch yamllint yq 
 
 echo "Installing SRE packages..."
 sudo -u $mostCommonUser $brew_path tap liamg/tfsec


### PR DESCRIPTION
Adds `mkcert` and `nss` packages so we can use mkcert to create locally-trusted development certificates:

- Relates to this PR: https://github.com/SequenceHQ/sequence-web/pull/3782
- mkcert: https://github.com/FiloSottile/mkcert?tab=readme-ov-file#macos
- Ticket: https://linear.app/sequence-hq/issue/BADGE-395/add-mkcert-to-kandji-brew-packages