### PR TITLE
Remove mkcert & nss from engineer packages

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -59,7 +59,7 @@ sudo -u $mostCommonUser $brew_path tap homebrew/core
 sudo -u $mostCommonUser $brew_path install --cask google-cloud-sdk
 
 echo "Installing engineering packages..."
-sudo -u $mostCommonUser $brew_path install cloudflared coreutils gawk httpie jq mkcert nss pgcli postgresql pre-commit teleport watch yamllint yq 
+sudo -u $mostCommonUser $brew_path install cloudflared coreutils gawk httpie jq pgcli postgresql pre-commit teleport watch yamllint yq 
 
 echo "Installing SRE packages..."
 sudo -u $mostCommonUser $brew_path tap liamg/tfsec


### PR DESCRIPTION
Remove mkcert & nss from brew install since Sequence laptops no longer need it